### PR TITLE
fix volume key error

### DIFF
--- a/06_gpu_and_ml/diffusers/train_and_serve_diffusers_script.py
+++ b/06_gpu_and_ml/diffusers/train_and_serve_diffusers_script.py
@@ -356,7 +356,7 @@ class Model:
         from diffusers import DDIMScheduler, StableDiffusionPipeline
 
         # Reload the modal.Volume to ensure the latest state is accessible.
-        stub.volume.reload()
+        stub.model_volume.reload()
 
         # set up a hugging face inference pipeline using our model
         ddim = DDIMScheduler.from_pretrained(MODEL_DIR, subfolder="scheduler")


### PR DESCRIPTION
Reloading model weights from `stub.model_volume` instead of `stub.volume`. This was causing an error at inference time.

<!--
  ✍️ Write a short summary of your work. Screenshots and videos are welcome!
-->

### Type of Change

- [ ] New Example
- [ x] Example updates (Bug fixes, new features, etc.)
- [ ] Other (changes to the codebase, but not to examples)

## Checklist

- [x] Example is testable in synthetic monitoring system, or `lambda-test: false` is added to example frontmatter
- [x] Example does _not_ require third-party dependencies to be installed locally
- [x] Example pins all dependencies
- [x] Example dependencies with `version < 1` are pinned to minor version, `~=0.x.y`
- [x] Example specifies a `python_version` for the base image
- [x] Example is documented with comments throughout, in a [_Literate Programming_](https://en.wikipedia.org/wiki/Literate_programming) style.

## Outside contributors

You're great! Thanks for your contribution.
